### PR TITLE
Reduce call to firebase

### DIFF
--- a/app/src/main/java/com/effeta/miparroquiaandroid/common/Constants.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/common/Constants.kt
@@ -9,7 +9,7 @@ const val DATE_FORMAT: String = "dd-MM-yyyy"
 const val DAY_OF_WEEK: String = "EEEE"
 const val DATE_AND_MONTH: String = "dd MMMM"
 const val HOUR: String = "hh:mm a"
-const val ISO_8601_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSZZ"
+const val ISO_8601_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'"
 
 const val REQUEST_FINE_LOCATION: Int = 101
 

--- a/app/src/main/java/com/effeta/miparroquiaandroid/common/DateTimeConverters.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/common/DateTimeConverters.kt
@@ -3,6 +3,8 @@ package com.effeta.miparroquiaandroid.common
 import android.arch.persistence.room.TypeConverter
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
+import java.util.*
+
 
 /**
  * Created by aulate on 19/3/18.

--- a/app/src/main/java/com/effeta/miparroquiaandroid/common/Utils.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/common/Utils.kt
@@ -25,12 +25,12 @@ fun Calendar.toString(pattern: String): String {
     return simpleDateFormat.format(time)
 }
 
-fun DateTime.getStartDay(): Date {
-    return withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0).toDate()
+fun DateTime.getStartDay(): DateTime {
+    return withHourOfDay(0).withMinuteOfHour(0).withSecondOfMinute(0)
 }
 
-fun DateTime.getEndDay(): Date {
-    return withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59).toDate()
+fun DateTime.getEndDay(): DateTime {
+    return withHourOfDay(23).withMinuteOfHour(59).withSecondOfMinute(59)
 }
 
 fun View.changeBackground(resId: Int) {

--- a/app/src/main/java/com/effeta/miparroquiaandroid/di/viewModels/ViewModelComponent.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/di/viewModels/ViewModelComponent.kt
@@ -18,4 +18,6 @@ interface ViewModelComponent {
 
     fun inject(churchViewModel: ChurchViewModel)
 
+    fun inject(dataViewModel: DataViewModel)
+
 }

--- a/app/src/main/java/com/effeta/miparroquiaandroid/di/viewModels/ViewModelsModule.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/di/viewModels/ViewModelsModule.kt
@@ -41,6 +41,11 @@ abstract class ViewModelsModule {
     abstract fun bindEucharistViewModel(eucharistListViewModel: EucharistListViewModel): ViewModel
 
     @Binds
+    @IntoMap
+    @ViewModelKey(DataViewModel::class)
+    abstract fun bindDataViewModel(dataViewModel: DataViewModel): ViewModel
+
+    @Binds
     abstract fun bindViewModelFactory(factory: ViewModelFactory): ViewModelProvider.Factory
 
 }

--- a/app/src/main/java/com/effeta/miparroquiaandroid/repositories/ChurchRepository.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/repositories/ChurchRepository.kt
@@ -18,22 +18,16 @@ class ChurchRepository @Inject constructor(private val mChurchMapFirebaseChurch:
                                            private val mFirebaseStorageImages: FirebaseStorageImages) {
 
 
-    fun getChurches(): Observable<List<Church>> {
+    fun getChurchesFromFirebase(): Observable<List<Church>> {
         val parishKey = mSharedPreferences.getParishKey()
-        return Observable.concatArray(
-                getChurchesFromRoom(parishKey!!),
-                getChurchesFromFirebase(parishKey)
-        )
-    }
-
-    private fun getChurchesFromFirebase(parishKey: String): Observable<List<Church>> {
         return mChurchMapFirebaseChurch.getChurchListByParish(parishKey).doOnNext {
             mRoomChurch.insertAll(it)
         }
     }
 
-    private fun getChurchesFromRoom(parishKey: String): Observable<List<Church>> {
-        return mRoomChurch.getAllChurchesByParish(parishKey).toObservable()
+    fun getChurchesFromRoom(): Observable<List<Church>> {
+        val parishKey = mSharedPreferences.getParishKey()
+        return mRoomChurch.getAllChurchesByParish(parishKey!!).toObservable()
     }
 
     fun getChurch(churchKey: String): Observable<Church> {

--- a/app/src/main/java/com/effeta/miparroquiaandroid/repositories/EucharistRepository.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/repositories/EucharistRepository.kt
@@ -1,11 +1,17 @@
 package com.effeta.miparroquiaandroid.repositories
 
+import com.effeta.miparroquiaandroid.common.ISO_8601_DATE_FORMAT
+import com.effeta.miparroquiaandroid.common.getEndDay
+import com.effeta.miparroquiaandroid.common.getStartDay
 import com.effeta.miparroquiaandroid.models.Eucharist
 import com.effeta.miparroquiaandroid.services.firebase.FirebaseEucharist
+import com.effeta.miparroquiaandroid.services.room.dao.EucharistDao
 import com.effeta.miparroquiaandroid.services.sharedPref.SharedPreferencesHelper
+import com.effeta.miparroquiaandroid.utils.DayUtils
 import io.reactivex.Observable
 import org.joda.time.DateTime
 import javax.inject.Inject
+
 
 /** -*- coding: utf-8 -*-
  * This file was created by
@@ -13,7 +19,8 @@ import javax.inject.Inject
  * @Date:   14/3/18
  */
 class EucharistRepository @Inject constructor(private val mFirebaseEucharist: FirebaseEucharist,
-                                              private val mSharedPreferences: SharedPreferencesHelper) {
+                                              private val mSharedPreferences: SharedPreferencesHelper,
+                                              private val mEucharistDao: EucharistDao) {
 
 
     fun getEucharistsByParish(): Observable<List<Eucharist>> {
@@ -24,5 +31,21 @@ class EucharistRepository @Inject constructor(private val mFirebaseEucharist: Fi
     fun getEucharistsByParishAndDay(day: DateTime): Observable<List<Eucharist>> {
         val parishKey = mSharedPreferences.getParishKey()
         return mFirebaseEucharist.getEucharistsByParishAndDay(parishKey!!, day)
+    }
+
+    fun getEucharistsByParishAndDayFromRoom(day: DateTime): Observable<List<Eucharist>> {
+        val parishKey = mSharedPreferences.getParishKey()
+        return mEucharistDao.getEucharistsByDay(parishKey!!, day.getStartDay().toString(ISO_8601_DATE_FORMAT),
+                day.getEndDay().toString(ISO_8601_DATE_FORMAT)).toObservable()
+
+
+    }
+
+    fun getEucharistsFromFirebaseAndSave(): Observable<List<Eucharist>> {
+        val parishKey = mSharedPreferences.getParishKey()
+        val days = DayUtils.getDaysOfWeek()
+        return mFirebaseEucharist.getEucharistsByParishAndDays(parishKey!!, days.first(), days.last()).doOnNext {
+            mEucharistDao.insertAll(it)
+        }
     }
 }

--- a/app/src/main/java/com/effeta/miparroquiaandroid/repositories/EucharistRepository.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/repositories/EucharistRepository.kt
@@ -37,15 +37,16 @@ class EucharistRepository @Inject constructor(private val mFirebaseEucharist: Fi
         val parishKey = mSharedPreferences.getParishKey()
         return mEucharistDao.getEucharistsByDay(parishKey!!, day.getStartDay().toString(ISO_8601_DATE_FORMAT),
                 day.getEndDay().toString(ISO_8601_DATE_FORMAT)).toObservable()
-
-
     }
 
     fun getEucharistsFromFirebaseAndSave(): Observable<List<Eucharist>> {
         val parishKey = mSharedPreferences.getParishKey()
         val days = DayUtils.getDaysOfWeek()
         return mFirebaseEucharist.getEucharistsByParishAndDays(parishKey!!, days.first(), days.last()).doOnNext {
-            mEucharistDao.insertAll(it)
+            if (!it.isEmpty()) {
+                mEucharistDao.deleteAllEucharists()
+                mEucharistDao.insertAll(it)
+            }
         }
     }
 }

--- a/app/src/main/java/com/effeta/miparroquiaandroid/services/firebase/FirebaseEucharist.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/services/firebase/FirebaseEucharist.kt
@@ -71,6 +71,26 @@ class FirebaseEucharist @Inject constructor() {
         }
     }
 
+
+    fun getEucharistsByParishAndDays(parishKey: String, startDay: DateTime,endDay: DateTime): Observable<List<Eucharist>> {
+        val fromDay = startDay.getStartDay().toDate()
+        val toDay = endDay.getEndDay().toDate()
+        return Observable.create<List<Eucharist>> {
+            eucharists
+                    .whereEqualTo(Eucharist.Properties.parish, parishKey)
+                    .whereGreaterThanOrEqualTo(Eucharist.Properties.hour, fromDay)
+                    .whereLessThanOrEqualTo(Eucharist.Properties.hour, toDay)
+                    .get().addOnCompleteListener { task ->
+                        if (task.isSuccessful) {
+                            it.onNext(parseEucharistList(task))
+                            it.onComplete()
+                        } else {
+                            it.onError(task.exception!!)
+                        }
+                    }
+        }
+    }
+
     private fun parseEucharistList(task: Task<QuerySnapshot>): List<Eucharist> {
         val list = ArrayList<Eucharist>()
         task.result.documents.forEach({ documentSnapshot ->

--- a/app/src/main/java/com/effeta/miparroquiaandroid/services/room/dao/EucharistDao.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/services/room/dao/EucharistDao.kt
@@ -7,6 +7,8 @@ import android.arch.persistence.room.Query
 import com.effeta.miparroquiaandroid.models.Eucharist
 import com.effeta.miparroquiaandroid.services.room.MiParroquiaDB
 import io.reactivex.Single
+import org.joda.time.DateTime
+import java.util.*
 
 /**
  * Created by aulate on 19/3/18.
@@ -21,9 +23,9 @@ interface EucharistDao {
     fun getAllEucharistsByParish(parishKey: String): Single<List<Eucharist>>
 
     @Query("SELECT * FROM ${MiParroquiaDB.EUCHARISTS_TABLENAME} WHERE ${Eucharist.Properties.parish} = :parishKey " +
-            "AND date(${Eucharist.Properties.hour}) = date(:day) " +
+            "AND date(${Eucharist.Properties.hour}) BETWEEN date(:startDay) AND date(:endDay)" +
             "ORDER BY ${Eucharist.Properties.hour}")
-    fun getEucharistsByDay(parishKey: String, day: String): Single<List<Eucharist>>
+    fun getEucharistsByDay(parishKey: String, startDay: String,endDay: String): Single<List<Eucharist>>
 
     @Query("SELECT COUNT(*) FROM ${MiParroquiaDB.EUCHARISTS_TABLENAME} WHERE ${Eucharist.Properties.parish} = :parishKey " +
             "AND date(${Eucharist.Properties.hour}) = date(:day) " +

--- a/app/src/main/java/com/effeta/miparroquiaandroid/services/room/dao/EucharistDao.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/services/room/dao/EucharistDao.kt
@@ -1,9 +1,6 @@
 package com.effeta.miparroquiaandroid.services.room.dao
 
-import android.arch.persistence.room.Dao
-import android.arch.persistence.room.Insert
-import android.arch.persistence.room.OnConflictStrategy
-import android.arch.persistence.room.Query
+import android.arch.persistence.room.*
 import com.effeta.miparroquiaandroid.models.Eucharist
 import com.effeta.miparroquiaandroid.services.room.MiParroquiaDB
 import io.reactivex.Single
@@ -40,4 +37,8 @@ interface EucharistDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAll(eucharists: List<Eucharist>)
+
+    @Query("DELETE FROM ${MiParroquiaDB.EUCHARISTS_TABLENAME}")
+    fun deleteAllEucharists()
+
 }

--- a/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/ChurchListViewModel.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/ChurchListViewModel.kt
@@ -13,35 +13,17 @@ import javax.inject.Inject
  * @Author: jjimenez
  * @Date:   2/26/18
  */
-class ChurchListViewModel @Inject constructor(private val mChurchRepository: ChurchRepository,
-                                              private val mEucharistRepository: EucharistRepository) : ViewModel() {
+class ChurchListViewModel @Inject constructor(private val mChurchRepository: ChurchRepository) : ViewModel() {
 
     private var mChurchList: MutableLiveData<List<Church>> = MutableLiveData()
 
-    private var mEucharistList: MutableLiveData<List<Eucharist>> = MutableLiveData()
-
     var isError: MutableLiveData<Boolean> = MutableLiveData()
 
-    init {
-    }
-
     fun getChurches(): MutableLiveData<List<Church>> {
-        //first try to get from firebase
-        mChurchRepository.getChurchesFromFirebase().subscribe {
-            //them get the churches from database
             mChurchRepository.getChurchesFromRoom().subscribe { list ->
                 mChurchList.postValue(list)
             }
-        }
         return mChurchList
-    }
-
-
-    fun getEucharists(): MutableLiveData<List<Eucharist>> {
-        mEucharistRepository.getEucharistsFromFirebaseAndSave().subscribe { list ->
-            mEucharistList.postValue(list)
-        }
-        return mEucharistList
     }
 
 }

--- a/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/ChurchListViewModel.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/ChurchListViewModel.kt
@@ -3,7 +3,9 @@ package com.effeta.miparroquiaandroid.viewmodel
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import com.effeta.miparroquiaandroid.models.Church
+import com.effeta.miparroquiaandroid.models.Eucharist
 import com.effeta.miparroquiaandroid.repositories.ChurchRepository
+import com.effeta.miparroquiaandroid.repositories.EucharistRepository
 import javax.inject.Inject
 
 /** -*- coding: utf-8 -*-
@@ -11,18 +13,36 @@ import javax.inject.Inject
  * @Author: jjimenez
  * @Date:   2/26/18
  */
-class ChurchListViewModel @Inject constructor(mChurchRepository: ChurchRepository) : ViewModel() {
+class ChurchListViewModel @Inject constructor(private val mChurchRepository: ChurchRepository,
+                                              private val mEucharistRepository: EucharistRepository) : ViewModel() {
 
     private var mChurchList: MutableLiveData<List<Church>> = MutableLiveData()
+
+    private var mEucharistList: MutableLiveData<List<Eucharist>> = MutableLiveData()
 
     var isError: MutableLiveData<Boolean> = MutableLiveData()
 
     init {
-        mChurchRepository.getChurches()
-                .subscribe { list ->
-                    mChurchList.postValue(list)
-                }
     }
 
-    fun getChurches() = mChurchList
+    fun getChurches(): MutableLiveData<List<Church>> {
+        //first try to get from firebase
+        mChurchRepository.getChurchesFromFirebase().subscribe {
+            //them get the churches from database
+            mChurchRepository.getChurchesFromRoom().subscribe { list ->
+                mChurchList.postValue(list)
+            }
+        }
+        return mChurchList
+    }
+
+
+    fun getEucharists(): MutableLiveData<List<Eucharist>> {
+        mEucharistRepository.getEucharistsFromFirebaseAndSave().subscribe { list ->
+            mEucharistList.postValue(list)
+        }
+        return mEucharistList
+    }
+
 }
+

--- a/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/DataViewModel.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/DataViewModel.kt
@@ -15,16 +15,9 @@ class DataViewModel @Inject constructor(private val mChurchRepository: ChurchRep
         //first try to get from firebase
         mChurchRepository.getChurchesFromFirebase().subscribe {
             //them get the churches from database
-            getChurchesFromRoom()
-        }
-        return isDataSaved
-    }
-
-    private fun getChurchesFromRoom() {
-        mChurchRepository.getChurchesFromRoom().subscribe { list ->
-            // And finally get the Eucharists
             getEucharistsFromFirebaseAndSave()
         }
+        return isDataSaved
     }
 
     private fun getEucharistsFromFirebaseAndSave() {

--- a/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/DataViewModel.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/DataViewModel.kt
@@ -2,48 +2,33 @@ package com.effeta.miparroquiaandroid.viewmodel
 
 import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
-import com.effeta.miparroquiaandroid.models.Church
-import com.effeta.miparroquiaandroid.models.Eucharist
 import com.effeta.miparroquiaandroid.repositories.ChurchRepository
 import com.effeta.miparroquiaandroid.repositories.EucharistRepository
 import javax.inject.Inject
 
 class DataViewModel @Inject constructor(private val mChurchRepository: ChurchRepository,
-                                              private val mEucharistRepository: EucharistRepository) : ViewModel() {
+                                        private val mEucharistRepository: EucharistRepository) : ViewModel() {
+    
+    var isDataSaved: MutableLiveData<Boolean> = MutableLiveData()
 
-    private var mChurchList: MutableLiveData<List<Church>> = MutableLiveData()
-
-    private var mEucharistList: MutableLiveData<List<Eucharist>> = MutableLiveData()
-
-    var isError: MutableLiveData<Boolean> = MutableLiveData()
-
-    var isDataSaved : MutableLiveData<Boolean> = MutableLiveData()
-
-    fun getData(): MutableLiveData<Boolean>{
+    fun getData(): MutableLiveData<Boolean> {
         //first try to get from firebase
         mChurchRepository.getChurchesFromFirebase().subscribe {
             //them get the churches from database
             getChurchesFromRoom()
         }
-
         return isDataSaved
     }
 
-    fun getChurches() =  mChurchList
-
-    fun getEucharists()= mEucharistList
-
-    private fun getChurchesFromRoom(){
+    private fun getChurchesFromRoom() {
         mChurchRepository.getChurchesFromRoom().subscribe { list ->
-            mChurchList.value = list
             // And finally get the Eucharists
             getEucharistsFromFirebaseAndSave()
         }
     }
-    private fun getEucharistsFromFirebaseAndSave(){
 
+    private fun getEucharistsFromFirebaseAndSave() {
         mEucharistRepository.getEucharistsFromFirebaseAndSave().subscribe { eucharists ->
-            mEucharistList.value = eucharists
             isDataSaved.postValue(true)
         }
     }

--- a/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/DataViewModel.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/DataViewModel.kt
@@ -8,8 +8,8 @@ import javax.inject.Inject
 
 class DataViewModel @Inject constructor(private val mChurchRepository: ChurchRepository,
                                         private val mEucharistRepository: EucharistRepository) : ViewModel() {
-    
-    var isDataSaved: MutableLiveData<Boolean> = MutableLiveData()
+
+    private var isDataSaved: MutableLiveData<Boolean> = MutableLiveData()
 
     fun getData(): MutableLiveData<Boolean> {
         //first try to get from firebase

--- a/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/DataViewModel.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/DataViewModel.kt
@@ -1,0 +1,52 @@
+package com.effeta.miparroquiaandroid.viewmodel
+
+import android.arch.lifecycle.MutableLiveData
+import android.arch.lifecycle.ViewModel
+import com.effeta.miparroquiaandroid.models.Church
+import com.effeta.miparroquiaandroid.models.Eucharist
+import com.effeta.miparroquiaandroid.repositories.ChurchRepository
+import com.effeta.miparroquiaandroid.repositories.EucharistRepository
+import javax.inject.Inject
+
+class DataViewModel @Inject constructor(private val mChurchRepository: ChurchRepository,
+                                              private val mEucharistRepository: EucharistRepository) : ViewModel() {
+
+    private var mChurchList: MutableLiveData<List<Church>> = MutableLiveData()
+
+    private var mEucharistList: MutableLiveData<List<Eucharist>> = MutableLiveData()
+
+    var isError: MutableLiveData<Boolean> = MutableLiveData()
+
+    var isDataSaved : MutableLiveData<Boolean> = MutableLiveData()
+
+    fun getData(): MutableLiveData<Boolean>{
+        //first try to get from firebase
+        mChurchRepository.getChurchesFromFirebase().subscribe {
+            //them get the churches from database
+            getChurchesFromRoom()
+        }
+
+        return isDataSaved
+    }
+
+    fun getChurches() =  mChurchList
+
+    fun getEucharists()= mEucharistList
+
+    private fun getChurchesFromRoom(){
+        mChurchRepository.getChurchesFromRoom().subscribe { list ->
+            mChurchList.value = list
+            // And finally get the Eucharists
+            getEucharistsFromFirebaseAndSave()
+        }
+    }
+    private fun getEucharistsFromFirebaseAndSave(){
+
+        mEucharistRepository.getEucharistsFromFirebaseAndSave().subscribe { eucharists ->
+            mEucharistList.value = eucharists
+            isDataSaved.postValue(true)
+        }
+    }
+
+}
+

--- a/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/EucharistListViewModel.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/EucharistListViewModel.kt
@@ -16,14 +16,10 @@ class EucharistListViewModel @javax.inject.Inject constructor(private val mEucha
 
     private var mEucharists: MutableLiveData<List<Eucharist>> = MutableLiveData()
 
-    init {
-
-    }
-
     fun getWeekDays() = DayUtils.getDaysOfWeek()
 
     fun getEucharistsByDay(day: DateTime): MutableLiveData<List<Eucharist>> {
-        mEucharistRepository.getEucharistsByParishAndDay(day).subscribe {
+        mEucharistRepository.getEucharistsByParishAndDayFromRoom(day).subscribe {
             mEucharists.postValue(it)
         }
         return mEucharists

--- a/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/MapViewModel.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/MapViewModel.kt
@@ -15,8 +15,8 @@ import com.google.android.gms.location.LocationSettingsRequest
 import javax.inject.Inject
 
 /**
-* Created by jjimenez on 3/7/18.
-*/
+ * Created by jjimenez on 3/7/18.
+ */
 class MapViewModel @Inject constructor(application: Application) : AndroidViewModel(application) {
 
     private var mLocationRequest: LocationRequest = LocationRequest()

--- a/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/ParishViewModel.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/viewmodel/ParishViewModel.kt
@@ -16,24 +16,25 @@ class ParishViewModel @Inject constructor(
 
     private var mParish: MutableLiveData<Parish> = MutableLiveData()
 
-    init {
+    fun getParishes(): MutableLiveData<List<Parish>> {
         mParishRepository.getParishes().subscribe {
             mParishList.postValue(it)
         }
-        if (mParishRepository.hasParishStored()) {
-            mParishRepository.getParish().subscribe {
-                mParish.postValue(it)
-            }
-        }
+        return mParishList
     }
-
-    fun getParishes() = mParishList
 
     fun storeSelectedParish(parishKey: String) {
         mParishRepository.storeParish(parishKey)
     }
 
-    fun getParish() = mParish
+    fun getParish(): MutableLiveData<Parish> {
+        if (mParishRepository.hasParishStored()) {
+            mParishRepository.getParish().subscribe {
+                mParish.postValue(it)
+            }
+        }
+        return mParish
+    }
 
     fun hasParishStored(): Boolean {
         return mParishRepository.hasParishStored()

--- a/app/src/main/java/com/effeta/miparroquiaandroid/views/activities/MainActivity.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/views/activities/MainActivity.kt
@@ -53,7 +53,6 @@ class MainActivity : NavDrawerActivity() {
 
         override fun onPageSelected(position: Int) {
         }
-
     }
 
     private var prevMenuItem: MenuItem? = null
@@ -77,7 +76,9 @@ class MainActivity : NavDrawerActivity() {
 
     override fun observeLiveData() {
         mChurchViewModel.getChurches().observe(this, Observer {
-            setupViewPager(viewpager)
+            mChurchViewModel.getEucharists().observe(this, Observer {
+                setupViewPager(viewpager)
+            })
         })
     }
 

--- a/app/src/main/java/com/effeta/miparroquiaandroid/views/activities/MainActivity.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/views/activities/MainActivity.kt
@@ -9,6 +9,7 @@ import android.view.MenuItem
 import com.effeta.miparroquiaandroid.R
 import com.effeta.miparroquiaandroid.common.NavDrawerActivity
 import com.effeta.miparroquiaandroid.viewmodel.ChurchListViewModel
+import com.effeta.miparroquiaandroid.viewmodel.DataViewModel
 import com.effeta.miparroquiaandroid.views.adapters.ViewPagerAdapter
 import com.effeta.miparroquiaandroid.views.fragments.AnnouncementsFragment
 import com.effeta.miparroquiaandroid.views.fragments.EucharistFragment
@@ -57,7 +58,7 @@ class MainActivity : NavDrawerActivity() {
 
     private var prevMenuItem: MenuItem? = null
 
-    private lateinit var mChurchViewModel: ChurchListViewModel
+    private lateinit var mDataViewModel: DataViewModel
 
     override val mLayout: Int = R.layout.activity_main
 
@@ -66,7 +67,7 @@ class MainActivity : NavDrawerActivity() {
     override val mTitle: Int? = R.string.app_name
 
     override fun initializeViewModels() {
-        mChurchViewModel = ViewModelProviders.of(this, viewModelFactory).get(ChurchListViewModel::class.java)
+        mDataViewModel = ViewModelProviders.of(this, viewModelFactory).get(DataViewModel::class.java)
     }
 
     override fun initializeUI() {
@@ -75,10 +76,11 @@ class MainActivity : NavDrawerActivity() {
     }
 
     override fun observeLiveData() {
-        mChurchViewModel.getChurches().observe(this, Observer {
-            mChurchViewModel.getEucharists().observe(this, Observer {
+
+        mDataViewModel.getData().observe(this, Observer {
+            if(it!!) {
                 setupViewPager(viewpager)
-            })
+            }
         })
     }
 

--- a/app/src/main/java/com/effeta/miparroquiaandroid/views/fragments/ParishMapFragment.kt
+++ b/app/src/main/java/com/effeta/miparroquiaandroid/views/fragments/ParishMapFragment.kt
@@ -78,13 +78,7 @@ class ParishMapFragment : BaseFragment(), OnMapReadyCallback, GoogleMap.OnMarker
     }
 
     override fun observeLiveData(isNewActivity: Boolean) {
-        getViewLifecycleOwner()?.let {
-            mMapViewModel.hasPermission.observe(it, Observer { hasPermission ->
-                if (!hasPermission!!) {
-                    requestLocationPermissions()
-                }
-            })
-        }
+
     }
 
     private fun initMapFragment() {
@@ -98,6 +92,15 @@ class ParishMapFragment : BaseFragment(), OnMapReadyCallback, GoogleMap.OnMarker
      */
     override fun onMapReady(googleMap: GoogleMap) {
         mMap = googleMap
+
+        getViewLifecycleOwner()?.let {
+            mMapViewModel.hasPermission.observe(it, Observer { hasPermission ->
+                if (!hasPermission!!) {
+                    requestLocationPermissions()
+                }
+            })
+        }
+
         mMap.uiSettings.isZoomControlsEnabled = true
         mMap.uiSettings.isCompassEnabled = true
         // Add a marker in San Jose Costa Rica and move the camera


### PR DESCRIPTION
## Scope

The scope for this PR is reduce the calls to firebase, and made the majority of request locally.   

## Implementation

Change time converter to made local queries.
Remove init function, because in some times this method is called each time the presenter is created, and the call to firebase should be call only when is necessary... 

Remove the Observable.concatArray because this made the Observable call two times, the logic was split in two method, one to call firebase and save the results and the other to get the local result.

Save the eucharists local (TODO remove old eucharists...) 

And fix one crash on the map fragment.  

---

![GIF]()
